### PR TITLE
Add case for "remastered" detection based on common spotify track titles

### DIFF
--- a/src/filter.js
+++ b/src/filter.js
@@ -417,7 +417,8 @@ class MetadataFilter {
 			// Dancing Days (2012 Remaster)
 			{ source: /\(\d+(\s-)?\sRemaster\)$/, target: '' },
 			// Outside The Wall - 2011 - Remaster
-			{ source: /-\s\d+\s-\sRemaster$/, target: '' },
+			// China Grove - 2006 Remaster
+			{ source: /-\s\d+(\s-)?\sRemaster$/, target: '' },
 			// Learning To Fly - 2001 Digital Remaster
 			{ source: /-\s\d+\s.+?\sRemaster$/, target: '' },
 			// Your Possible Pasts - 2011 Remastered Version

--- a/test/filter.js
+++ b/test/filter.js
@@ -363,6 +363,10 @@ const REMASTERED_FILTER_RULES_TEST_DATA = [{
 	source: 'Track Title - 2011 - Remaster',
 	expected: 'Track Title '
 }, {
+	description: 'should remove "- YYYY Remaster" string',
+	source: 'Track Title - 2006 Remaster',
+	expected: 'Track Title '
+}, {
 	description: 'should remove "- YYYY Digital Remaster" string',
 	source: 'Track Title - 2001 Digital Remaster',
 	expected: 'Track Title '


### PR DESCRIPTION
This is a format I see frequently in Spotify track titles that doesn't
seem to be picked up by all the other supported cases.