### PR TITLE
Add parodies track title filter

### DIFF
--- a/src/filters.ts
+++ b/src/filters.ts
@@ -7,6 +7,7 @@ import {
 	removeCleanExplicit,
 	removeFeature,
 	removeLive,
+	removeParody,
 	removeRemastered,
 	removeVersion,
 	youtube,
@@ -40,7 +41,7 @@ export function getRemasteredFilter(): MetadataFilter {
  */
 export function getSpotifyFilter(): MetadataFilter {
 	return new MetadataFilter({
-		track: [removeRemastered, fixTrackSuffix, removeLive],
+		track: [removeRemastered, removeParody, fixTrackSuffix, removeLive],
 		album: [removeRemastered, fixTrackSuffix, removeLive],
 	});
 }

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -3,6 +3,7 @@ import {
 	FEATURE_FILTER_RULES,
 	LIVE_FILTER_RULES,
 	NORMALIZE_FEATURE_FILTER_RULES,
+	PARODY_FILTER_RULES,
 	REMASTERED_FILTER_RULES,
 	SUFFIX_FILTER_RULES,
 	TRIM_SYMBOLS_FILTER_RULES,
@@ -165,6 +166,16 @@ export function removeRemastered(text: string): string {
  */
 export function removeVersion(text: string): string {
 	return filterWithFilterRules(text, VERSION_FILTER_RULES);
+}
+
+/**
+ * Remove "(Parody of "X" by Y)"-like strings from the text.
+ * @param text String to be filtered
+ *
+ * @return Filtered string
+ */
+export function removeParody(text: string): string {
+	return filterWithFilterRules(text, PARODY_FILTER_RULES);
 }
 
 /**

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -188,3 +188,12 @@ export const SUFFIX_FILTER_RULES: FilterRule[] = [
 	// Remove "- Original" suffix
 	{ source: /-\sOriginal$/i, target: '' },
 ];
+
+export const PARODY_FILTER_RULES: FilterRule[] = [
+	// Party In the CIA (Parody of "Party In The U.S.A." by Miley Cyrus)
+	{ source: /\s\(Parody of ".*" by .*\)$/, target: '' },
+	// White & Nerdy (Parody of "Ridin'" by Chamillionaire feat. Krayzie Bone)
+	{ source: /\s\(Parody of ".*" by .* feat\. .*\)$/, target: '' },
+	// The Saga Begins (Lyrical Adaption of "American Pie")
+	{ source: /\s\(Lyrical Adaption of ".*"\)$/, target: '' },
+];

--- a/test/function/remove-parody.spec.ts
+++ b/test/function/remove-parody.spec.ts
@@ -1,0 +1,26 @@
+import { removeParody } from '../../src/functions';
+
+import { testFilterFunction } from '../helper/test-function';
+
+testFilterFunction(removeParody, [
+	{
+		description: `should remove ' (Parody of "Party In The U.S.A." by Miley Cyrus)' string`,
+		funcParameter: 'Party In the CIA (Parody of "Party In The U.S.A." by Miley Cyrus)',
+		expectedValue: 'Party In the CIA',
+	},
+	{
+		description: `should remove ' (Parody of "Gangsta's Paradise" by Coolio)' string`,
+		funcParameter: `Amish Paradise (Parody of "Gangsta's Paradise" by Coolio)`,
+		expectedValue: 'Amish Paradise',
+	},
+	{
+		description: `should remove ' (Parody of "Ridin'" by Chamillionaire feat. Krayzie Bone)' string`,
+		funcParameter: `White & Nerdy (Parody of "Ridin'" by Chamillionaire feat. Krayzie Bone)`,
+		expectedValue: 'White & Nerdy',
+	},
+	{
+		description: `should remove ' (Lyrical Adaption of "American Pie")' string`,
+		funcParameter: 'The Saga Begins (Lyrical Adaption of "American Pie")',
+		expectedValue: 'The Saga Begins',
+	},
+]);


### PR DESCRIPTION
This new filter aims to strip track titles of parody notes. It primarily
targets "Weird Al" Yankovic, whose songs on Spotify tend to include
things such as '(Parody of "X" by Y)' on the end. The new filters are
turned on automatically for Spotify track titles.

This aims to resolve #81