### PR TITLE
Turn on additional typescript strictness settings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,12 @@
 {
   "compilerOptions": {
     "esModuleInterop": true,
-    "strict": true
+    "strict": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*", "test/**/*"]
 }


### PR DESCRIPTION
I felt it was better to keep these separate from the linting configuration updates because they weren't strictly related to the build process.