### PR TITLE
Minor adjustment to two regular expressions targeting symbol trimming

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -85,9 +85,9 @@ export const TRIM_SYMBOLS_FILTER_RULES: FilterRule[] = [
 	// Leftovers after e.g. (official video)
 	{ source: /\(+\s*\)+/, target: '' },
 	// trim starting white chars and dash
-	{ source: /^[/,:;~-\s"]+/, target: '' },
+	{ source: /^[/,:;~\s"-]+/, target: '' },
 	// trim trailing white chars and dash
-	{ source: /[/,:;~-\s"]+$/, target: '' },
+	{ source: /[/,:;~\s"-]+$/, target: '' },
 	// remove multiple spaces
 	{ source: /\s{1,}/, target: ' ' },
 ];


### PR DESCRIPTION
By moving the dash character to the end of the character list in these expressions, it makes the fact that it is not meant to be used as a character range separator more explicit. It also makes these expressions valid in Python. It does not (appear to) change how they behave at all in Javascript.