### PR TITLE
Add some more version rules

### DIFF
--- a/src/filters.ts
+++ b/src/filters.ts
@@ -65,7 +65,7 @@ export function getRemasteredFilter(): MetadataFilter {
 export function createSpotifyFilter(): MetadataFilter {
 	return new MetadataFilter({
 		track: [removeRemastered, removeParody, fixTrackSuffix, removeLive],
-		album: [removeRemastered, fixTrackSuffix, removeLive, removeReissue],
+		album: [removeRemastered, fixTrackSuffix, removeLive, removeReissue, removeVersion],
 	});
 }
 

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -65,7 +65,7 @@ export function getRemasteredFilter(): MetadataFilter {
 export function createSpotifyFilter(): MetadataFilter {
 	return new MetadataFilter({
 		track: [removeRemastered, removeParody, fixTrackSuffix, removeLive],
-		album: [removeRemastered, fixTrackSuffix, removeLive, removeReissue, removeVersion],
+		album: [removeRemastered, fixTrackSuffix, removeLive, removeReissue],
 	});
 }
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -159,7 +159,7 @@ export const VERSION_FILTER_RULES: FilterRule[] = [
 	{ source: /[([]Bonus Track Edition[)\]]/i, target: '' },
 	// Peace Sells...But Who's Buying (25th Anniversary)
 	// Persistence of Time (30th Anniversary Remaster)
-	{ source: /[([]\d+th\sAnniversary.*[)\]]/i, target: '' }
+	{ source: /[([]\d+th\sAnniversary.*[)\]]/i, target: '' },
 ];
 
 /**

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -147,8 +147,19 @@ export const VERSION_FILTER_RULES: FilterRule[] = [
 	{ source: /-\sStereo Version$/, target: '' },
 	// Pure McCartney (Deluxe Edition)
 	{ source: /\(Deluxe Edition\)$/, target: '' },
+	// Ace of Spades (Expanded Edition)
+	// Overkill (Expanded Bonus Track Edition)
+	// On Parole (Expanded and Remastered)
+	{ source: /[([]Expanded.*[)\]]$/, target: '' },
+	// Sound of White Noise - Expanded Edition
+	{ source: /-\sExpanded Edition$/, target: '' },
 	// 6 Foot 7 Foot (Explicit Version)
 	{ source: /[([]Explicit Version[)\]]/i, target: '' },
+	// No Remorse (Bonus Track Edition)
+	{ source: /[([]Bonus Track Edition[)\]]/i, target: '' },
+	// Peace Sells...But Who's Buying (25th Anniversary)
+	// Persistence of Time (30th Anniversary Remaster)
+	{ source: /[([]\d+th\sAnniversary.*[)\]]/i, target: '' }
 ];
 
 /**

--- a/test/fixtures/functions/remove-version.json
+++ b/test/fixtures/functions/remove-version.json
@@ -105,17 +105,17 @@
     "expectedValue": "Album Title "
   },
   {
-    "description": "should remove '(25th Anniversary)' string",
+    "description": "should remove '(XXth Anniversary)' string",
     "funcParameter": "Album Title (25th Anniversary)",
     "expectedValue": "Album Title "
   },
   {
-    "description": "should remove '[25th Anniversary]' string",
+    "description": "should remove '[XXth Anniversary]' string",
     "funcParameter": "Album Title [25th Anniversary]",
     "expectedValue": "Album Title "
   },
   {
-    "description": "should remove '(30th Anniversary Remaster)' string",
+    "description": "should remove '(XXth Anniversary Remaster)' string",
     "funcParameter": "Album Title (30th Anniversary Remaster)",
     "expectedValue": "Album Title "
   }

--- a/test/fixtures/functions/remove-version.json
+++ b/test/fixtures/functions/remove-version.json
@@ -58,5 +58,65 @@
     "description": "should remove '(Deluxe Edition)' string",
     "funcParameter": "Album Title (Deluxe Edition)",
     "expectedValue": "Album Title "
+  },
+  {
+    "description": "should remove '(Expanded Edition)' string",
+    "funcParameter": "Album Title (Expanded Edition)",
+    "expectedValue": "Album Title "
+  },
+  {
+    "description": "should remove '[Expanded Edition]' string",
+    "funcParameter": "Album Title [Expanded Edition]",
+    "expectedValue": "Album Title "
+  },
+  {
+    "description": "should remove '(Expanded Bonus Track Edition)' string",
+    "funcParameter": "Album Title (Expanded Bonus Track Edition)",
+    "expectedValue": "Album Title "
+  },
+  {
+    "description": "should remove '(Expanded and Remastered)' string",
+    "funcParameter": "Album Title (Expanded and Remastered)",
+    "expectedValue": "Album Title "
+  },
+  {
+    "description": "should remove '- Expanded Edition' string",
+    "funcParameter": "Album Title - Expanded Edition",
+    "expectedValue": "Album Title "
+  },
+  {
+    "description": "should remove '(Explicit Version)' string",
+    "funcParameter": "Album Title (Explicit Version)",
+    "expectedValue": "Album Title "
+  },
+  {
+    "description": "should remove '[Explicit Version]' string",
+    "funcParameter": "Album Title [Explicit Version]",
+    "expectedValue": "Album Title "
+  },
+  {
+    "description": "should remove '(Bonus Track Edition)' string",
+    "funcParameter": "Album Title (Bonus Track Edition)",
+    "expectedValue": "Album Title "
+  },
+  {
+    "description": "should remove '[Bonus Track Edition]' string",
+    "funcParameter": "Album Title [Bonus Track Edition]",
+    "expectedValue": "Album Title "
+  },
+  {
+    "description": "should remove '(25th Anniversary)' string",
+    "funcParameter": "Album Title (25th Anniversary)",
+    "expectedValue": "Album Title "
+  },
+  {
+    "description": "should remove '[25th Anniversary]' string",
+    "funcParameter": "Album Title [25th Anniversary]",
+    "expectedValue": "Album Title "
+  },
+  {
+    "description": "should remove '30th Anniversary Remaster' string",
+    "funcParameter": "Album Title (30th Anniversary Remaster)",
+    "expectedValue": "Album Title "
   }
 ]

--- a/test/fixtures/functions/remove-version.json
+++ b/test/fixtures/functions/remove-version.json
@@ -115,7 +115,7 @@
     "expectedValue": "Album Title "
   },
   {
-    "description": "should remove '30th Anniversary Remaster' string",
+    "description": "should remove '(30th Anniversary Remaster)' string",
     "funcParameter": "Album Title (30th Anniversary Remaster)",
     "expectedValue": "Album Title "
   }


### PR DESCRIPTION
I've added some new "version" rules based on my experiences with Spotify (which is where all of the commented examples are taken from). I also added `removeVersion` to the Spotify filter since all of the version rules there seem to be frequent occurrences there. This was tested in a new app I'm working on.