### PR TITLE
Remove Original suffix using removeVersion

### DIFF
--- a/src/filters.ts
+++ b/src/filters.ts
@@ -65,7 +65,7 @@ export function getRemasteredFilter(): MetadataFilter {
 export function createSpotifyFilter(): MetadataFilter {
 	return new MetadataFilter({
 		track: [removeRemastered, removeParody, fixTrackSuffix, removeLive],
-		album: [removeRemastered, fixTrackSuffix, removeLive, removeReissue],
+		album: [removeRemastered, fixTrackSuffix, removeLive, removeReissue, removeVersion],
 	});
 }
 

--- a/src/filters.ts
+++ b/src/filters.ts
@@ -65,7 +65,13 @@ export function getRemasteredFilter(): MetadataFilter {
 export function createSpotifyFilter(): MetadataFilter {
 	return new MetadataFilter({
 		track: [removeRemastered, removeParody, fixTrackSuffix, removeLive],
-		album: [removeRemastered, fixTrackSuffix, removeLive, removeReissue, removeVersion],
+		album: [
+			removeRemastered,
+			fixTrackSuffix,
+			removeLive,
+			removeReissue,
+			removeVersion,
+		],
 	});
 }
 

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -153,7 +153,7 @@ export const VERSION_FILTER_RULES: FilterRule[] = [
 	// Personal Jesus - Original Single Version
 	// Prince of the Moment - Original 7" Version
 	// YMCA - Original Version 1978
-	{ source: /-\sOriginal.*Version( \d{4})?$/i, target: '' },
+	{ source: /-\sOriginal.*Version(\s\d{4})?$/i, target: '' },
 ];
 
 /**

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -108,8 +108,6 @@ export const SUFFIX_FILTER_RULES: FilterRule[] = [
 		target: '($1 $2)',
 	},
 	{ source: /-\s(Remix|VIP|Instrumental)$/i, target: '($1)' },
-	// Remove "- Original" suffix
-	{ source: /-\sOriginal$/i, target: '' },
 ];
 
 /**
@@ -149,6 +147,12 @@ export const VERSION_FILTER_RULES: FilterRule[] = [
 	{ source: /\(Deluxe Edition\)$/, target: '' },
 	// 6 Foot 7 Foot (Explicit Version)
 	{ source: /[([]Explicit Version[)\]]/i, target: '' },
+	// 6 Foot 7 Foot - Original
+	{ source: /-\sOriginal$/i, target: '' },
+	// California Love - Original Version
+	{ source: /-\sOriginal Version$/i, target: '' },
+	// Personal Jesus - Original Single Version
+	{ source: /-\sOriginal Single Version$/i, target: '' },
 ];
 
 /**

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -150,9 +150,10 @@ export const VERSION_FILTER_RULES: FilterRule[] = [
 	// 6 Foot 7 Foot - Original
 	{ source: /-\sOriginal$/i, target: '' },
 	// California Love - Original Version
-	{ source: /-\sOriginal Version$/i, target: '' },
 	// Personal Jesus - Original Single Version
-	{ source: /-\sOriginal Single Version$/i, target: '' },
+	// Prince of the Moment - Original 7" Version
+	// YMCA - Original Version 1978
+	{ source: /-\sOriginal.*Version( \d{4})?$/i, target: '' },
 ];
 
 /**

--- a/test/fixtures/functions/fix-track-suffix.json
+++ b/test/fixtures/functions/fix-track-suffix.json
@@ -53,10 +53,5 @@
     "description": "should replace 'Instrumental' suffix",
     "funcParameter": "Track Title - Instrumental",
     "expectedValue": "Track Title (Instrumental)"
-  },
-  {
-    "description": "should remove '- Original' sufix",
-    "funcParameter": "Track Title - Original",
-    "expectedValue": "Track Title "
   }
 ]

--- a/test/fixtures/functions/remove-version.json
+++ b/test/fixtures/functions/remove-version.json
@@ -73,5 +73,15 @@
     "description": "should remove '- Original Single Version' sufix",
     "funcParameter": "Track Title - Original Single Version",
     "expectedValue": "Track Title "
+  },
+  {
+    "description": "should remove '- Original 7\" Version' sufix",
+    "funcParameter": "Track Title - Original 7\" Version",
+    "expectedValue": "Track Title "
+  },
+  {
+    "description": "should remove '- Original Version YYYY' sufix",
+    "funcParameter": "Track Title - Original Version 1978",
+    "expectedValue": "Track Title "
   }
 ]

--- a/test/fixtures/functions/remove-version.json
+++ b/test/fixtures/functions/remove-version.json
@@ -58,5 +58,20 @@
     "description": "should remove '(Deluxe Edition)' string",
     "funcParameter": "Album Title (Deluxe Edition)",
     "expectedValue": "Album Title "
+  },
+  {
+    "description": "should remove '- Original' sufix",
+    "funcParameter": "Track Title - Original",
+    "expectedValue": "Track Title "
+  },
+  {
+    "description": "should remove '- Original Version' sufix",
+    "funcParameter": "Track Title - Original Version",
+    "expectedValue": "Track Title "
+  },
+  {
+    "description": "should remove '- Original Single Version' sufix",
+    "funcParameter": "Track Title - Original Single Version",
+    "expectedValue": "Track Title "
   }
 ]


### PR DESCRIPTION
Closes #114. Interestingly enough, when I was searching Spotify I didn't find any that had "- Original", but I did find a few that had "- Original Version" and at least one that had "- Original Single Version", so I decided to include those as well.