### PR TITLE
Generalize the remastered rules

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -79,7 +79,6 @@ export const REMASTERED_FILTER_RULES: FilterRule[] = [
 	{ source: /-\sRe-?[Mm]aster(ed)?.*$/, target: '' },
 	// Learning To Fly - 2001 Digital Remaster
 	{ source: /-\s\d+\s.+?\sRemaster$/, target: '' },
-
 	// Wish You Were Here [Remastered] (Remastered Version)
 	{ source: /\[Remastered\]\s\(Remastered\sVersion\)$/, target: '' },
 ];

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -64,6 +64,8 @@ export const REISSUE_FILTER_RULES: FilterRule[] = [
  * Filter rules to remove "Remastered..."-like strings from a text.
  */
 export const REMASTERED_FILTER_RULES: FilterRule[] = [
+	// Vivo (Live / Remastered)
+	{ source: /[([]Live\s\/\sRemastered[)\]]$/, target: '(Live)' },
 	// Mothership (Remastered)
 	// Let It Be (Remastered 2009)
 	// How The West Was Won [Remastered]
@@ -77,7 +79,7 @@ export const REMASTERED_FILTER_RULES: FilterRule[] = [
 	// Red Right Hand - 2011 Remastered Version
 	{ source: /-\s\d{4}(\s-)?\s.*Re-?[Mm]aster(ed)?.*$/, target: '' },
 	// Ticket To Ride - Live / Remastered
-	{ source: /-\sLive\s\/\sRemastered$/, target: '' },
+	{ source: /-\sLive\s\/\sRemastered$/, target: '- Live' },
 	// Here Comes The Sun - Remastered
 	// 1979 - Remastered 2012
 	// 1979 - Remastered Version

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -64,8 +64,8 @@ export const REISSUE_FILTER_RULES: FilterRule[] = [
  * Filter rules to remove "Remastered..."-like strings from a text.
  */
 export const REMASTERED_FILTER_RULES: FilterRule[] = [
-	// Vivo (Live / Remastered)
-	{ source: /[([]Live\s\/\sRemastered[)\]]$/, target: '(Live)' },
+	// Ticket To Ride - Live / Remastered
+	{ source: /Live\s\/\sRemastered/, target: 'Live' },
 	// Mothership (Remastered)
 	// Let It Be (Remastered 2009)
 	// How The West Was Won [Remastered]
@@ -78,8 +78,6 @@ export const REMASTERED_FILTER_RULES: FilterRule[] = [
 	// Learning To Fly - 2001 Digital Remaster
 	// Red Right Hand - 2011 Remastered Version
 	{ source: /-\s\d{4}(\s-)?\s.*Re-?[Mm]aster(ed)?.*$/, target: '' },
-	// Ticket To Ride - Live / Remastered
-	{ source: /-\sLive\s\/\sRemastered$/, target: '- Live' },
 	// Here Comes The Sun - Remastered
 	// 1979 - Remastered 2012
 	// 1979 - Remastered Version

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -75,7 +75,7 @@ export const REMASTERED_FILTER_RULES: FilterRule[] = [
 	// Easy Living - 2003 Remastered
 	// Learning To Fly - 2001 Digital Remaster
 	// Red Right Hand - 2011 Remastered Version
-	{ source: /-\s\d+(\s-)?\s.*Re-?[Mm]aster(ed)?.*$/, target: '' },
+	{ source: /-\s\d{4}(\s-)?\s.*Re-?[Mm]aster(ed)?.*$/, target: '' },
 	// Ticket To Ride - Live / Remastered
 	{ source: /-\sLive\s\/\sRemastered$/, target: '' },
 	// Here Comes The Sun - Remastered

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -74,7 +74,10 @@ export const REMASTERED_FILTER_RULES: FilterRule[] = [
 	// China Grove - 2006 Remaster
 	// Easy Living - 2003 Remastered
 	// Learning To Fly - 2001 Digital Remaster
-	{ source: /-\s\d+(\s-)?\s.*Re-?[Mm]aster(ed)?$/, target: '' },
+	// Red Right Hand - 2011 Remastered Version
+	{ source: /-\s\d+(\s-)?\s.*Re-?[Mm]aster(ed)?.*$/, target: '' },
+	// Ticket To Ride - Live / Remastered
+	{ source: /-\sLive\s\/\sRemastered$/, target: '' },
 	// Here Comes The Sun - Remastered
 	// 1979 - Remastered 2012
 	// 1979 - Remastered Version

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -70,15 +70,15 @@ export const REMASTERED_FILTER_RULES: FilterRule[] = [
 	// Ride the Lightning (Deluxe Remaster)
 	// ...And Justice For All (Remastered Deluxe Box Set)
 	{ source: /[([].*Re-?[Mm]aster(ed)?.*[)\]]$/, target: '' },
-	// Here Comes The Sun - Remastered
 	// Outside The Wall - 2011 - Remaster
 	// China Grove - 2006 Remaster
 	// Easy Living - 2003 Remastered
-	{ source: /-\s\d+(\s-)?\sRemaster(?:ed)?$/, target: '' },
-	// 1979 - Remastered 2012
-	{ source: /-\sRe-?[Mm]aster(ed)?.*$/, target: '' },
 	// Learning To Fly - 2001 Digital Remaster
-	{ source: /-\s\d+\s.+?\sRemaster$/, target: '' },
+	{ source: /-\s\d+(\s-)?\s.*Re-?[Mm]aster(ed)?$/, target: '' },
+	// Here Comes The Sun - Remastered
+	// 1979 - Remastered 2012
+	// 1979 - Remastered Version
+	{ source: /-\sRe-?[Mm]aster(ed)?.*$/, target: '' },
 	// Wish You Were Here [Remastered] (Remastered Version)
 	{ source: /\[Remastered\]\s\(Remastered\sVersion\)$/, target: '' },
 ];

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -64,39 +64,22 @@ export const REISSUE_FILTER_RULES: FilterRule[] = [
  * Filter rules to remove "Remastered..."-like strings from a text.
  */
 export const REMASTERED_FILTER_RULES: FilterRule[] = [
-	// Here Comes The Sun - Remastered
-	{ source: /-\sRemastered$/, target: '' },
-	// Hey Jude - Remastered 2015
-	{ source: /-\sRemastered\s\d+$/, target: '' },
+	// Mothership (Remastered)
 	// Let It Be (Remastered 2009)
-	// Red Rain (Remaster 2012)
-	{ source: /\(Remaster(ed)?\s\d+\)$/, target: '' },
-	// Pigs On The Wing (Part One) [2011 - Remaster]
-	{ source: /\[\d+\s-\sRemaster\]$/, target: '' },
-	// Comfortably Numb (2011 - Remaster)
-	// Dancing Days (2012 Remaster)
-	{ source: /\(\d+(\s-)?\sRemaster\)$/, target: '' },
+	// How The West Was Won [Remastered]
+	// Ride the Lightning (Deluxe Remaster)
+	// ...And Justice For All (Remastered Deluxe Box Set)
+	{ source: /[([].*Re-?[Mm]aster(ed)?.*[)\]]$/, target: '' },
+	// Here Comes The Sun - Remastered
 	// Outside The Wall - 2011 - Remaster
 	// China Grove - 2006 Remaster
 	// Easy Living - 2003 Remastered
 	{ source: /-\s\d+(\s-)?\sRemaster(?:ed)?$/, target: '' },
+	// 1979 - Remastered 2012
+	{ source: /-\sRe-?[Mm]aster(ed)?.*$/, target: '' },
 	// Learning To Fly - 2001 Digital Remaster
 	{ source: /-\s\d+\s.+?\sRemaster$/, target: '' },
-	// Your Possible Pasts - 2011 Remastered Version
-	{ source: /-\s\d+\sRemastered Version$/, target: '' },
-	// Roll Over Beethoven (Live / Remastered)
-	{ source: /\(Live\s\/\sRemastered\)$/i, target: '' },
-	// Ticket To Ride - Live / Remastered
-	{ source: /-\sLive\s\/\sRemastered$/, target: '' },
-	// Mothership (Remastered)
-	// How The West Was Won [Remastered]
-	{ source: /[([]Remastered[)\]]$/, target: '' },
-	// A Well Respected Man (2014 Remastered Version)
-	// A Well Respected Man [2014 Remastered Version]
-	{ source: /[([]\d{4} Re[Mm]astered Version[)\]]$/, target: '' },
-	// She Was Hot (2009 Re-Mastered Digital Version)
-	// She Was Hot (2009 Remastered Digital Version)
-	{ source: /[([]\d{4} Re-?[Mm]astered Digital Version[)\]]$/, target: '' },
+
 	// Wish You Were Here [Remastered] (Remastered Version)
 	{ source: /\[Remastered\]\s\(Remastered\sVersion\)$/, target: '' },
 ];

--- a/test/fixtures/functions/remove-remastered.json
+++ b/test/fixtures/functions/remove-remastered.json
@@ -85,6 +85,26 @@
     "expectedValue": "Track Title "
   },
   {
+    "description": "should remove '(Deluxe Remaster)' string",
+    "funcParameter": "Track Title (Deluxe Remaster)",
+    "expectedValue": "Track Title "
+  },
+  {
+    "description": "should remove '[Deluxe Remaster]' string",
+    "funcParameter": "Track Title [Deluxe Remaster]",
+    "expectedValue": "Track Title "
+  },
+  {
+    "description": "should remove '(Remastered Deluxe Box Set)' string",
+    "funcParameter": "Track Title (Remastered Deluxe Box Set)",
+    "expectedValue": "Track Title "
+  },
+  {
+    "description": "should remove '[Remastered Deluxe Box Set]' string",
+    "funcParameter": "Track Title [Remastered Deluxe Box Set]",
+    "expectedValue": "Track Title "
+  },
+  {
     "description": "should remove '(YYYY Remastered Version)' string",
     "funcParameter": "Track Title (2014 Remastered Version)",
     "expectedValue": "Track Title "

--- a/test/fixtures/functions/remove-remastered.json
+++ b/test/fixtures/functions/remove-remastered.json
@@ -67,12 +67,12 @@
   {
     "description": "should remove '(Live / Remastered)' string",
     "funcParameter": "Track Title (Live / Remastered)",
-    "expectedValue": "Track Title "
+    "expectedValue": "Track Title (Live)"
   },
   {
     "description": "should remove '- Live / Remastered' string",
     "funcParameter": "Track Title - Live / Remastered",
-    "expectedValue": "Track Title "
+    "expectedValue": "Track Title - Live"
   },
   {
     "description": "should remove '(Remastered)' string",


### PR DESCRIPTION
This is somewhat of a drastic change, so feel free to leave feedback if you have a better way to handle this. I needed to add rules for **"Deluxe Remaster"**, **"Remastered Deluxe Box Set"**, **"Remastered 30th Anniversary Deluxe Edition",** and similar items, and this led me to the idea of generalizing the remaster rules to work with any string that has **"Remaster"** in it somewhere. I combined a ton of the rules so that they'd be more generalized. 

The only thing I couldn't figure out how to wildcard was the case of having something after a dash and before the word "Remaster" (e.g. **"- Live / Remastered"**), because a wildcard there might screw with titles that have dashes in them. So I think those will still need to be added on a case-by-case basis.

All of the preexisting tests pass, and I added some new ones for my use cases. Let me know if you have any concerns or if there's anything I should add.