### PR TITLE
Add rule for (Live)

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -32,9 +32,11 @@ export const FEATURE_FILTER_RULES: FilterRule[] = [
 
 export const LIVE_FILTER_RULES: FilterRule[] = [
 	// Track - Live
-	{ source: /-\sLive?$/, target: '' },
 	// Track - Live at
-	{ source: /-\sLive\s.+?$/, target: '' },
+	{ source: /-\sLive(\s.+)?$/, target: '' },
+	// Track (Live)
+	{ source: /[([]Live[)\]]$/, target: '' },
+
 ];
 
 export const NORMALIZE_FEATURE_FILTER_RULES = [

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -36,7 +36,6 @@ export const LIVE_FILTER_RULES: FilterRule[] = [
 	{ source: /-\sLive(\s.+)?$/, target: '' },
 	// Track (Live)
 	{ source: /[([]Live[)\]]$/, target: '' },
-
 ];
 
 export const NORMALIZE_FEATURE_FILTER_RULES = [

--- a/test/fixtures/functions/remove-live.json
+++ b/test/fixtures/functions/remove-live.json
@@ -8,5 +8,10 @@
     "description": "should remove 'Live ...' suffix",
     "funcParameter": "Track Title - Live @ Moon",
     "expectedValue": "Track Title "
+  },
+  {
+    "description": "should remove '(Live)' suffix",
+    "funcParameter": "Track Title (Live)",
+    "expectedValue": "Track Title "
   }
 ]


### PR DESCRIPTION
- Added rule for (Live) and [Live]
- Simplified two existing Live rules into one by moving the whitespace inside the capture group