### PR TITLE
Improve support for Japanese youtube titles

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -157,6 +157,8 @@ export const VERSION_FILTER_RULES: FilterRule[] = [
  * Filter rules to remove YouTube suffixes and prefixes from a text.
  */
 export const YOUTUBE_TRACK_FILTER_RULES: FilterRule[] = [
+	// Remove - preceding opening bracket
+	{ source: /-([「【『])/, target: '$1' },
 	// Trim whitespaces
 	{ source: /^\s+|\s+$/g, target: '' },
 	// **NEW**
@@ -168,21 +170,24 @@ export const YOUTUBE_TRACK_FILTER_RULES: FilterRule[] = [
 	// Video extensions
 	{ source: /\.(avi|wmv|mpg|mpeg|flv)$/i, target: '' },
 	// (Lyrics Video)
-	{ source: /\(.*lyrics?\s*(video)?\)/i, target: '' },
+	{ source: /[(【)].*lyrics?\s*(video)?[)】]/i, target: '' },
 	// ((Official)? (Track)? Stream)
-	{ source: /\((of+icial\s*)?(track\s*)?stream\)/i, target: '' },
+	{ source: /[(【)](of+icial\s*)?(track\s*)?stream[)】]/i, target: '' },
 	// ((Official)? (Music)? Video|Audio)
-	{ source: /\((of+icial\s*)?(music\s*)?(video|audio)\)/i, target: '' },
+	{
+		source: /[(【)](of+icial\s*)?(music\s*)?(video|audio)[)】]/i,
+		target: '',
+	},
 	// - (Official)? (Music)? Video|Audio
 	{ source: /-\s(of+icial\s*)?(music\s*)?(video|audio)$/i, target: '' },
 	// ((Whatever)? Album Track)
-	{ source: /\(.*Album\sTrack\)/i, target: '' },
+	{ source: /[(【)].*Album\sTrack[)】]/i, target: '' },
 	// (Official)
-	{ source: /\(\s*of+icial\s*\)/i, target: '' },
+	{ source: /[(【)]\s*of+icial\s*[)】]/i, target: '' },
 	// (1999)
-	{ source: /\(\s*[0-9]{4}\s*\)/i, target: '' },
+	{ source: /[(【)]\s*[0-9]{4}\s*[)】]/i, target: '' },
 	// (HD) / (HQ)
-	{ source: /\(\s*(HD|HQ)\s*\)$/, target: '' },
+	{ source: /[(【)]\s*(HD|HQ)\s*[)】]$/, target: '' },
 	// HD / HQ
 	{ source: /(HD|HQ)\s?$/, target: '' },
 	// Video Clip Officiel / Video Clip Official
@@ -204,7 +209,10 @@ export const YOUTUBE_TRACK_FILTER_RULES: FilterRule[] = [
 	// 'Track title'
 	{ source: /^(|.*\s)'(.{5,})'(\s.*|)$/, target: '$2' },
 	// (*01/01/1999*)
-	{ source: /\(.*[0-9]{1,2}\/[0-9]{1,2}\/[0-9]{2,4}.*\)/i, target: '' },
+	{
+		source: /[(【)].*[0-9]{1,2}\/[0-9]{1,2}\/[0-9]{2,4}.*[)】]/i,
+		target: '',
+	},
 	// Sub Español
 	{ source: /sub\s*español/i, target: '' },
 	// (Letra)
@@ -214,13 +222,11 @@ export const YOUTUBE_TRACK_FILTER_RULES: FilterRule[] = [
 	// Sub Español
 	{ source: /sub\s*español/i, target: '' },
 	// 【/(*Music Video/MV/PV*】/)
-	{ source: /[(【].*?((Music Video)|(MV)|(PV)).*?[】)]/i, target: '' },
+	{ source: /[(【].*?((MV)|(PV)).*?[】)]/i, target: '' },
 	// 【/(東方/オリジナル*】/)
 	{ source: /[(【]((オリジナル)|(東方)).*?[】)]/, target: '' },
 	// MV/PV if not followed by an opening/closing bracket or if ending
 	{ source: /(MV|PV)([「【『』】」]|$)/i, target: '$2' },
-	// Remove - preceding opening bracket
-	{ source: /-([「【『])/, target: '$1' },
 ];
 
 /**

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -219,6 +219,8 @@ export const YOUTUBE_TRACK_FILTER_RULES: FilterRule[] = [
 	{ source: /(\(|【)((オリジナル)|(東方)).*?(】|\))/i, target: '' },
 	// MV/PV if not followed by an opening/closing bracket or if ending
 	{ source: /(MV|PV)(「|【|『|】|』|」|$)/i, target: '$2' },
+	// Remove - preceding opening bracket
+	{ source: /-(「|『|【)/, target: '$1' }
 ];
 
 /**

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -216,7 +216,7 @@ export const YOUTUBE_TRACK_FILTER_RULES: FilterRule[] = [
 	//【/(*Music Video/MV/PV*】/)
 	{ source: /(\(|【).*?((Music Video)|(MV)|(PV)).*?(】|\))/i, target: '' },
 	//【/(東方/オリジナル*】/)
-	{ source: /(\(|【)((オリジナル)|(東方)).*?(】|\))/i, target: '' },
+	{ source: /(\(|【)((オリジナル)|(東方)).*?(】|\))/, target: '' },
 	// MV/PV if not followed by an opening/closing bracket or if ending
 	{ source: /(MV|PV)(「|【|『|】|』|」|$)/i, target: '$2' },
 	// Remove - preceding opening bracket

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -214,13 +214,13 @@ export const YOUTUBE_TRACK_FILTER_RULES: FilterRule[] = [
 	// Sub Español
 	{ source: /sub\s*español/i, target: '' },
 	// 【/(*Music Video/MV/PV*】/)
-	{ source: /(\(|【).*?((Music Video)|(MV)|(PV)).*?(】|\))/i, target: '' },
+	{ source: /[(【].*?((Music Video)|(MV)|(PV)).*?[】)]/i, target: '' },
 	// 【/(東方/オリジナル*】/)
-	{ source: /(\(|【)((オリジナル)|(東方)).*?(】|\))/, target: '' },
+	{ source: /[(【]((オリジナル)|(東方)).*?[】)]/, target: '' },
 	// MV/PV if not followed by an opening/closing bracket or if ending
-	{ source: /(MV|PV)(「|【|『|】|』|」|$)/i, target: '$2' },
+	{ source: /(MV|PV)([「【『』】」]|$)/i, target: '$2' },
 	// Remove - preceding opening bracket
-	{ source: /-(「|『|【)/, target: '$1' },
+	{ source: /-([「【『])/, target: '$1' },
 ];
 
 /**

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -213,14 +213,14 @@ export const YOUTUBE_TRACK_FILTER_RULES: FilterRule[] = [
 	{ source: /\s\(En\svivo\)/i, target: '' },
 	// Sub Español
 	{ source: /sub\s*español/i, target: '' },
-	//【/(*Music Video/MV/PV*】/)
+	// 【/(*Music Video/MV/PV*】/)
 	{ source: /(\(|【).*?((Music Video)|(MV)|(PV)).*?(】|\))/i, target: '' },
-	//【/(東方/オリジナル*】/)
+	// 【/(東方/オリジナル*】/)
 	{ source: /(\(|【)((オリジナル)|(東方)).*?(】|\))/, target: '' },
 	// MV/PV if not followed by an opening/closing bracket or if ending
 	{ source: /(MV|PV)(「|【|『|】|』|」|$)/i, target: '$2' },
 	// Remove - preceding opening bracket
-	{ source: /-(「|『|【)/, target: '$1' }
+	{ source: /-(「|『|【)/, target: '$1' },
 ];
 
 /**

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -157,37 +157,36 @@ export const VERSION_FILTER_RULES: FilterRule[] = [
  * Filter rules to remove YouTube suffixes and prefixes from a text.
  */
 export const YOUTUBE_TRACK_FILTER_RULES: FilterRule[] = [
-	// Remove - preceding opening bracket
-	{ source: /-([「【『])/, target: '$1' },
 	// Trim whitespaces
 	{ source: /^\s+|\s+$/g, target: '' },
 	// **NEW**
 	{ source: /\*+\s?\S+\s?\*+$/, target: '' },
 	// [Whatever]
 	{ source: /\[[^\]]+\]/, target: '' },
+	// 【Whatever】
+	{ source: /【[^\]]+】/, target: '' },
+	// （Whatever）
+	{ source: /（[^\]]+）/, target: '' },
 	// (Whatever Version)
 	{ source: /\([^)]*version\)$/i, target: '' },
 	// Video extensions
 	{ source: /\.(avi|wmv|mpg|mpeg|flv)$/i, target: '' },
 	// (Lyrics Video)
-	{ source: /[(【)].*lyrics?\s*(video)?[)】]/i, target: '' },
+	{ source: /\(.*lyrics?\s*(video)?\)/i, target: '' },
 	// ((Official)? (Track)? Stream)
-	{ source: /[(【)](of+icial\s*)?(track\s*)?stream[)】]/i, target: '' },
+	{ source: /\((of+icial\s*)?(track\s*)?stream\)/i, target: '' },
 	// ((Official)? (Music)? Video|Audio)
-	{
-		source: /[(【)](of+icial\s*)?(music\s*)?(video|audio)[)】]/i,
-		target: '',
-	},
+	{ source: /\((of+icial\s*)?(music\s*)?(video|audio)\)/i, target: '' },
 	// - (Official)? (Music)? Video|Audio
 	{ source: /-\s(of+icial\s*)?(music\s*)?(video|audio)$/i, target: '' },
 	// ((Whatever)? Album Track)
-	{ source: /[(【)].*Album\sTrack[)】]/i, target: '' },
+	{ source: /\(.*Album\sTrack\)/i, target: '' },
 	// (Official)
-	{ source: /[(【)]\s*of+icial\s*[)】]/i, target: '' },
+	{ source: /\(\s*of+icial\s*\)/i, target: '' },
 	// (1999)
-	{ source: /[(【)]\s*[0-9]{4}\s*[)】]/i, target: '' },
+	{ source: /\(\s*[0-9]{4}\s*\)/i, target: '' },
 	// (HD) / (HQ)
-	{ source: /[(【)]\s*(HD|HQ)\s*[)】]$/, target: '' },
+	{ source: /\(\s*(HD|HQ)\s*\)$/, target: '' },
 	// HD / HQ
 	{ source: /(HD|HQ)\s?$/, target: '' },
 	// Video Clip Officiel / Video Clip Official
@@ -209,10 +208,7 @@ export const YOUTUBE_TRACK_FILTER_RULES: FilterRule[] = [
 	// 'Track title'
 	{ source: /^(|.*\s)'(.{5,})'(\s.*|)$/, target: '$2' },
 	// (*01/01/1999*)
-	{
-		source: /[(【)].*[0-9]{1,2}\/[0-9]{1,2}\/[0-9]{2,4}.*[)】]/i,
-		target: '',
-	},
+	{ source: /\(.*[0-9]{1,2}\/[0-9]{1,2}\/[0-9]{2,4}.*\)/i, target: '' },
 	// Sub Español
 	{ source: /sub\s*español/i, target: '' },
 	// (Letra)
@@ -221,12 +217,6 @@ export const YOUTUBE_TRACK_FILTER_RULES: FilterRule[] = [
 	{ source: /\s\(En\svivo\)/i, target: '' },
 	// Sub Español
 	{ source: /sub\s*español/i, target: '' },
-	// 【/(*Music Video/MV/PV*】/)
-	{ source: /[(【].*?((MV)|(PV)).*?[】)]/i, target: '' },
-	// 【/(東方/オリジナル*】/)
-	{ source: /[(【]((オリジナル)|(東方)).*?[】)]/, target: '' },
-	// MV/PV if not followed by an opening/closing bracket or if ending
-	{ source: /(MV|PV)([「【『』】」]|$)/i, target: '$2' },
 ];
 
 /**

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -213,6 +213,12 @@ export const YOUTUBE_TRACK_FILTER_RULES: FilterRule[] = [
 	{ source: /\s\(En\svivo\)/i, target: '' },
 	// Sub Español
 	{ source: /sub\s*español/i, target: '' },
+	//【/(*Music Video/MV/PV*】/)
+	{ source: /(\(|【).*?((Music Video)|(MV)|(PV)).*?(】|\))/i, target: '' },
+	//【/(東方/オリジナル*】/)
+	{ source: /(\(|【)((オリジナル)|(東方)).*?(】|\))/i, target: '' },
+	// MV/PV if not followed by an opening/closing bracket or if ending
+	{ source: /(MV|PV)(「|【|『|】|』|」|$)/i, target: '$2' },
 ];
 
 /**

--- a/test/fixtures/functions/youtube.json
+++ b/test/fixtures/functions/youtube.json
@@ -480,11 +480,6 @@
     "expectedValue": "Artist name「Track title」"
   },
 	{
-    "description": "should remove 'MV' in string if before 】",
-    "funcParameter": "Artist name【Track titleMV】",
-    "expectedValue": "Artist name【Track title】"
-  },
-	{
     "description": "should remove 'MV' in string if before 』",
     "funcParameter": "Artist name『Track titleMV』",
     "expectedValue": "Artist name『Track title』"

--- a/test/fixtures/functions/youtube.json
+++ b/test/fixtures/functions/youtube.json
@@ -475,21 +475,6 @@
     "expectedValue": "Artist name『Track title』"
   },
 	{
-    "description": "should remove 'MV' in string if before 」",
-    "funcParameter": "Artist name「Track titleMV」",
-    "expectedValue": "Artist name「Track title」"
-  },
-	{
-    "description": "should remove 'MV' in string if before 】",
-    "funcParameter": "Artist name【Track titleMV】",
-    "expectedValue": "Artist name【Track title】"
-  },
-	{
-    "description": "should remove 'MV' in string if before 』",
-    "funcParameter": "Artist name『Track titleMV』",
-    "expectedValue": "Artist name『Track title』"
-  },
-	{
     "description": "should remove 'PV' string",
     "funcParameter": "Track Title PV",
     "expectedValue": "Track Title"
@@ -512,21 +497,6 @@
 	{
     "description": "should remove 'PV' in string if before 『",
     "funcParameter": "Artist namePV『Track title』",
-    "expectedValue": "Artist name『Track title』"
-  },
-	{
-    "description": "should remove 'PV' in string if before 」",
-    "funcParameter": "Artist name「Track titlePV」",
-    "expectedValue": "Artist name「Track title」"
-  },
-	{
-    "description": "should remove 'PV' in string if before 】",
-    "funcParameter": "Artist name【Track titlePV】",
-    "expectedValue": "Artist name【Track title】"
-  },
-	{
-    "description": "should remove 'PV' in string if before 』",
-    "funcParameter": "Artist name『Track titlePV』",
     "expectedValue": "Artist name『Track title』"
   },
   {

--- a/test/fixtures/functions/youtube.json
+++ b/test/fixtures/functions/youtube.json
@@ -95,6 +95,16 @@
     "expectedValue": "Track Title"
   },
   {
+    "description": "should remove '【whatever】' string",
+    "funcParameter": "Track Title 【Official Video】",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '（whatever）' string",
+    "funcParameter": "Track Title （Official Video）",
+    "expectedValue": "Track Title"
+  },
+  {
     "description": "should remove '[whatever] + (whatever)' string",
     "funcParameter": "Track Title [Official Video] (Official Video)",
     "expectedValue": "Track Title"
@@ -423,175 +433,5 @@
     "description": "should remove multiple spaces",
     "funcParameter": "Imminent (Lyric Video) ft. Joshua Idehen",
     "expectedValue": "Imminent ft. Joshua Idehen"
-  },
-  {
-    "description": "should remove '【Music Video】' string",
-    "funcParameter": "【Music Video】Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '【MV】' string",
-    "funcParameter": "【MV】Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '【Whatever MV】' string",
-    "funcParameter": "【Whatever MV】Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '【MV Whatever】' string",
-    "funcParameter": "【MV Whatever】Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '(MV)' string",
-    "funcParameter": "Track Title(MV)",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove 'MV' string",
-    "funcParameter": "Track Title MV",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should not remove 'MV' in string",
-    "funcParameter": "Omvei",
-    "expectedValue": "Omvei"
-  },
-  {
-    "description": "should remove 'MV' in string if before 「",
-    "funcParameter": "Artist nameMV「Track title」",
-    "expectedValue": "Artist name「Track title」"
-  },
-  {
-    "description": "should remove 'MV' in string if before 【",
-    "funcParameter": "Artist nameMV【Track title】",
-    "expectedValue": "Artist name【Track title】"
-  },
-  {
-    "description": "should remove 'MV' in string if before 『",
-    "funcParameter": "Artist nameMV『Track title』",
-    "expectedValue": "Artist name『Track title』"
-  },
-  {
-    "description": "should remove 'MV' in string if before 」",
-    "funcParameter": "Artist name「Track titleMV」",
-    "expectedValue": "Artist name「Track title」"
-  },
-  {
-    "description": "should remove 'MV' in string if before 』",
-    "funcParameter": "Artist name『Track titleMV』",
-    "expectedValue": "Artist name『Track title』"
-  },
-  {
-    "description": "should remove 'PV' string",
-    "funcParameter": "Track Title PV",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should not remove 'PV' in string",
-    "funcParameter": "Oppvakt",
-    "expectedValue": "Oppvakt"
-  },
-  {
-    "description": "should remove 'PV' in string if before 「",
-    "funcParameter": "Artist namePV「Track title」",
-    "expectedValue": "Artist name「Track title」"
-  },
-  {
-    "description": "should remove 'PV' in string if before 『",
-    "funcParameter": "Artist namePV『Track title』",
-    "expectedValue": "Artist name『Track title』"
-  },
-  {
-    "description": "should remove 'PV' in string if before 」",
-    "funcParameter": "Artist name「Track titlePV」",
-    "expectedValue": "Artist name「Track title」"
-  },
-  {
-    "description": "should remove 'PV' in string if before 』",
-    "funcParameter": "Artist name『Track titlePV』",
-    "expectedValue": "Artist name『Track title』"
-  },
-  {
-    "description": "should remove '【PV】' string",
-    "funcParameter": "【PV】Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '【Whatever PV】' string",
-    "funcParameter": "【Whatever PV】Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '【PV Whatever】' string",
-    "funcParameter": "【PV Whatever】Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '(PV)' string",
-    "funcParameter": "Track Title(PV)",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '(Whatever PV)' string",
-    "funcParameter": "(Whatever PV)Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '(PV Whatever)' string",
-    "funcParameter": "(PV Whatever)Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '(Whatever MV)' string",
-    "funcParameter": "(Whatever MV)Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '(MV Whatever)' string",
-    "funcParameter": "(MV Whatever)Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '【オリジナル】' string",
-    "funcParameter": "【オリジナル】Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '【オリジナルWhatever】' string",
-    "funcParameter": "【オリジナルWhatever】Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '【東方】' string",
-    "funcParameter": "【東方】Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '【東方Whatever】' string",
-    "funcParameter": "【東方Whatever】Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove dash from '-「' string",
-    "funcParameter": "Artist name -「Track Title」",
-    "expectedValue": "Artist name 「Track Title」"
-  },
-  {
-    "description": "should remove dash from '-『' string",
-    "funcParameter": "Artist name -『Track Title』",
-    "expectedValue": "Artist name 『Track Title』"
-  },
-  {
-    "description": "should remove dash from '-【' string",
-    "funcParameter": "Artist name -【Track Title】",
-    "expectedValue": "Artist name 【Track Title】"
-  },
-  {
-    "description": "should remove 【Official Video】string",
-    "funcParameter": "Artist name -Track Title-【Official Video】",
-    "expectedValue": "Artist name -Track Title"
   }
 ]

--- a/test/fixtures/functions/youtube.json
+++ b/test/fixtures/functions/youtube.json
@@ -475,6 +475,21 @@
     "expectedValue": "Artist name『Track title』"
   },
 	{
+    "description": "should remove 'MV' in string if before 」",
+    "funcParameter": "Artist name「Track titleMV」",
+    "expectedValue": "Artist name「Track title」"
+  },
+	{
+    "description": "should remove 'MV' in string if before 】",
+    "funcParameter": "Artist name【Track titleMV】",
+    "expectedValue": "Artist name【Track title】"
+  },
+	{
+    "description": "should remove 'MV' in string if before 』",
+    "funcParameter": "Artist name『Track titleMV』",
+    "expectedValue": "Artist name『Track title』"
+  },
+	{
     "description": "should remove 'PV' string",
     "funcParameter": "Track Title PV",
     "expectedValue": "Track Title"
@@ -497,6 +512,21 @@
 	{
     "description": "should remove 'PV' in string if before 『",
     "funcParameter": "Artist namePV『Track title』",
+    "expectedValue": "Artist name『Track title』"
+  },
+	{
+    "description": "should remove 'PV' in string if before 」",
+    "funcParameter": "Artist name「Track titlePV」",
+    "expectedValue": "Artist name「Track title」"
+  },
+	{
+    "description": "should remove 'PV' in string if before 】",
+    "funcParameter": "Artist name【Track titlePV】",
+    "expectedValue": "Artist name【Track title】"
+  },
+	{
+    "description": "should remove 'PV' in string if before 』",
+    "funcParameter": "Artist name『Track titlePV』",
     "expectedValue": "Artist name『Track title』"
   },
   {

--- a/test/fixtures/functions/youtube.json
+++ b/test/fixtures/functions/youtube.json
@@ -490,36 +490,6 @@
     "expectedValue": "Track Title"
   },
   {
-    "description": "should remove '[PV]' string",
-    "funcParameter": "[PV]Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '[Whatever PV]' string",
-    "funcParameter": "[Whatever PV]Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '[PV Whatever]' string",
-    "funcParameter": "[PV Whatever]Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '[MV]' string",
-    "funcParameter": "[MV]Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '[Whatever MV]' string",
-    "funcParameter": "[Whatever MV]Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
-    "description": "should remove '[MV Whatever]' string",
-    "funcParameter": "[MV Whatever]Track Title",
-    "expectedValue": "Track Title"
-  },
-  {
     "description": "should remove '(Whatever PV)' string",
     "funcParameter": "(Whatever PV)Track Title",
     "expectedValue": "Track Title"

--- a/test/fixtures/functions/youtube.json
+++ b/test/fixtures/functions/youtube.json
@@ -448,5 +448,115 @@
     "description": "should remove '(MV)' string",
     "funcParameter": "Track Title(MV)",
     "expectedValue": "Track Title"
+  },
+	{
+    "description": "should remove 'MV' string",
+    "funcParameter": "Track Title MV",
+    "expectedValue": "Track Title"
+  },
+	{
+    "description": "should not remove 'MV' in string",
+    "funcParameter": "Omvei",
+    "expectedValue": "Omvei"
+  },
+	{
+    "description": "should remove 'PV' string",
+    "funcParameter": "Track Title PV",
+    "expectedValue": "Track Title"
+  },
+	{
+    "description": "should not remove 'PV' in string",
+    "funcParameter": "Oppvakt",
+    "expectedValue": "Oppvakt"
+  },
+  {
+    "description": "should remove '【PV】' string",
+    "funcParameter": "【PV】Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '【Whatever PV】' string",
+    "funcParameter": "【Whatever PV】Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '【PV Whatever】' string",
+    "funcParameter": "【PV Whatever】Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(PV)' string",
+    "funcParameter": "Track Title(PV)",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '[PV]' string",
+    "funcParameter": "[PV]Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '[Whatever PV]' string",
+    "funcParameter": "[Whatever PV]Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '[PV Whatever]' string",
+    "funcParameter": "[PV Whatever]Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '[MV]' string",
+    "funcParameter": "[MV]Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '[Whatever MV]' string",
+    "funcParameter": "[Whatever MV]Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '[MV Whatever]' string",
+    "funcParameter": "[MV Whatever]Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(Whatever PV)' string",
+    "funcParameter": "(Whatever PV)Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(PV Whatever)' string",
+    "funcParameter": "(PV Whatever)Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(Whatever MV)' string",
+    "funcParameter": "(Whatever MV)Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(MV Whatever)' string",
+    "funcParameter": "(MV Whatever)Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '【オリジナル】' string",
+    "funcParameter": "【オリジナル】Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '【オリジナルWhatever】' string",
+    "funcParameter": "【オリジナルWhatever】Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '【東方】' string",
+    "funcParameter": "【東方】Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '【東方Whatever】' string",
+    "funcParameter": "【東方Whatever】Track Title",
+    "expectedValue": "Track Title"
   }
 ]

--- a/test/fixtures/functions/youtube.json
+++ b/test/fixtures/functions/youtube.json
@@ -449,67 +449,67 @@
     "funcParameter": "Track Title(MV)",
     "expectedValue": "Track Title"
   },
-	{
+  {
     "description": "should remove 'MV' string",
     "funcParameter": "Track Title MV",
     "expectedValue": "Track Title"
   },
-	{
+  {
     "description": "should not remove 'MV' in string",
     "funcParameter": "Omvei",
     "expectedValue": "Omvei"
   },
-	{
+  {
     "description": "should remove 'MV' in string if before 「",
     "funcParameter": "Artist nameMV「Track title」",
     "expectedValue": "Artist name「Track title」"
   },
-	{
+  {
     "description": "should remove 'MV' in string if before 【",
     "funcParameter": "Artist nameMV【Track title】",
     "expectedValue": "Artist name【Track title】"
   },
-	{
+  {
     "description": "should remove 'MV' in string if before 『",
     "funcParameter": "Artist nameMV『Track title』",
     "expectedValue": "Artist name『Track title』"
   },
-	{
+  {
     "description": "should remove 'MV' in string if before 」",
     "funcParameter": "Artist name「Track titleMV」",
     "expectedValue": "Artist name「Track title」"
   },
-	{
+  {
     "description": "should remove 'MV' in string if before 』",
     "funcParameter": "Artist name『Track titleMV』",
     "expectedValue": "Artist name『Track title』"
   },
-	{
+  {
     "description": "should remove 'PV' string",
     "funcParameter": "Track Title PV",
     "expectedValue": "Track Title"
   },
-	{
+  {
     "description": "should not remove 'PV' in string",
     "funcParameter": "Oppvakt",
     "expectedValue": "Oppvakt"
   },
-	{
+  {
     "description": "should remove 'PV' in string if before 「",
     "funcParameter": "Artist namePV「Track title」",
     "expectedValue": "Artist name「Track title」"
   },
-	{
+  {
     "description": "should remove 'PV' in string if before 『",
     "funcParameter": "Artist namePV『Track title』",
     "expectedValue": "Artist name『Track title』"
   },
-	{
+  {
     "description": "should remove 'PV' in string if before 」",
     "funcParameter": "Artist name「Track titlePV」",
     "expectedValue": "Artist name「Track title」"
   },
-	{
+  {
     "description": "should remove 'PV' in string if before 』",
     "funcParameter": "Artist name『Track titlePV』",
     "expectedValue": "Artist name『Track title』"

--- a/test/fixtures/functions/youtube.json
+++ b/test/fixtures/functions/youtube.json
@@ -423,5 +423,30 @@
     "description": "should remove multiple spaces",
     "funcParameter": "Imminent (Lyric Video) ft. Joshua Idehen",
     "expectedValue": "Imminent ft. Joshua Idehen"
+  },
+  {
+    "description": "should remove '【Music Video】' string",
+    "funcParameter": "【Music Video】Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '【MV】' string",
+    "funcParameter": "【MV】Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '【Whatever MV】' string",
+    "funcParameter": "【Whatever MV】Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '【MV Whatever】' string",
+    "funcParameter": "【MV Whatever】Track Title",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(MV)' string",
+    "funcParameter": "Track Title(MV)",
+    "expectedValue": "Track Title"
   }
 ]

--- a/test/fixtures/functions/youtube.json
+++ b/test/fixtures/functions/youtube.json
@@ -475,6 +475,21 @@
     "expectedValue": "Artist name『Track title』"
   },
 	{
+    "description": "should remove 'MV' in string if before 」",
+    "funcParameter": "Artist name「Track titleMV」",
+    "expectedValue": "Artist name「Track title」"
+  },
+	{
+    "description": "should remove 'MV' in string if before 】",
+    "funcParameter": "Artist name【Track titleMV】",
+    "expectedValue": "Artist name【Track title】"
+  },
+	{
+    "description": "should remove 'MV' in string if before 』",
+    "funcParameter": "Artist name『Track titleMV』",
+    "expectedValue": "Artist name『Track title』"
+  },
+	{
     "description": "should remove 'PV' string",
     "funcParameter": "Track Title PV",
     "expectedValue": "Track Title"
@@ -490,13 +505,18 @@
     "expectedValue": "Artist name「Track title」"
   },
 	{
-    "description": "should remove 'PV' in string if before 【",
-    "funcParameter": "Artist namePV【Track title】",
-    "expectedValue": "Artist name【Track title】"
-  },
-	{
     "description": "should remove 'PV' in string if before 『",
     "funcParameter": "Artist namePV『Track title』",
+    "expectedValue": "Artist name『Track title』"
+  },
+	{
+    "description": "should remove 'PV' in string if before 」",
+    "funcParameter": "Artist name「Track titlePV」",
+    "expectedValue": "Artist name「Track title」"
+  },
+	{
+    "description": "should remove 'PV' in string if before 』",
+    "funcParameter": "Artist name『Track titlePV』",
     "expectedValue": "Artist name『Track title』"
   },
   {

--- a/test/fixtures/functions/youtube.json
+++ b/test/fixtures/functions/youtube.json
@@ -588,5 +588,10 @@
     "description": "should remove dash from '-【' string",
     "funcParameter": "Artist name -【Track Title】",
     "expectedValue": "Artist name 【Track Title】"
+  },
+  {
+    "description": "should remove 【Official Video】string",
+    "funcParameter": "Artist name -Track Title-【Official Video】",
+    "expectedValue": "Artist name -Track Title"
   }
 ]

--- a/test/fixtures/functions/youtube.json
+++ b/test/fixtures/functions/youtube.json
@@ -460,6 +460,21 @@
     "expectedValue": "Omvei"
   },
 	{
+    "description": "should remove 'MV' in string if before 「",
+    "funcParameter": "Artist nameMV「Track title」",
+    "expectedValue": "Artist name「Track title」"
+  },
+	{
+    "description": "should remove 'MV' in string if before 【",
+    "funcParameter": "Artist nameMV【Track title】",
+    "expectedValue": "Artist name【Track title】"
+  },
+	{
+    "description": "should remove 'MV' in string if before 『",
+    "funcParameter": "Artist nameMV『Track title』",
+    "expectedValue": "Artist name『Track title』"
+  },
+	{
     "description": "should remove 'PV' string",
     "funcParameter": "Track Title PV",
     "expectedValue": "Track Title"
@@ -468,6 +483,21 @@
     "description": "should not remove 'PV' in string",
     "funcParameter": "Oppvakt",
     "expectedValue": "Oppvakt"
+  },
+	{
+    "description": "should remove 'PV' in string if before 「",
+    "funcParameter": "Artist namePV「Track title」",
+    "expectedValue": "Artist name「Track title」"
+  },
+	{
+    "description": "should remove 'PV' in string if before 【",
+    "funcParameter": "Artist namePV【Track title】",
+    "expectedValue": "Artist name【Track title】"
+  },
+	{
+    "description": "should remove 'PV' in string if before 『",
+    "funcParameter": "Artist namePV『Track title』",
+    "expectedValue": "Artist name『Track title』"
   },
   {
     "description": "should remove '【PV】' string",

--- a/test/fixtures/functions/youtube.json
+++ b/test/fixtures/functions/youtube.json
@@ -573,5 +573,20 @@
     "description": "should remove '【東方Whatever】' string",
     "funcParameter": "【東方Whatever】Track Title",
     "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove dash from '-「' string",
+    "funcParameter": "Artist name -「Track Title」",
+    "expectedValue": "Artist name 「Track Title」"
+  },
+  {
+    "description": "should remove dash from '-『' string",
+    "funcParameter": "Artist name -『Track Title』",
+    "expectedValue": "Artist name 『Track Title』"
+  },
+  {
+    "description": "should remove dash from '-【' string",
+    "funcParameter": "Artist name -【Track Title】",
+    "expectedValue": "Artist name 【Track Title】"
   }
 ]


### PR DESCRIPTION
Adds a couple of simple rules to clean up japanese youtube tags.
Should improve a few videos, like this one: https://youtu.be/tbhaY8EXP_Q
Based on my own experience I think these will have very few false positives