### PR TITLE
Remove (Official Visualiser) from YouTube title

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -185,6 +185,8 @@ export const YOUTUBE_TRACK_FILTER_RULES: FilterRule[] = [
 	{ source: /\(.*lyrics?\s*(video)?\)/i, target: '' },
 	// ((Official)? (Track)? Stream)
 	{ source: /\((of+icial\s*)?(track\s*)?stream\)/i, target: '' },
+	// ((Official)? (Track)? Visuali[sz]er)
+	{ source: /\((of+icial\s*)?(track\s*)?visuali[sz]er\)/i, target: '' },
 	// ((Official)? (Music|HD)? Video|Audio)
 	{ source: /\((of+icial\s*)?((music|hd)\s*)?(video|audio)\)/i, target: '' },
 	// - (Official)? (Music)? Video|Audio

--- a/test/fixtures/functions/youtube.json
+++ b/test/fixtures/functions/youtube.json
@@ -320,6 +320,31 @@
     "expectedValue": "Track Title"
   },
   {
+    "description": "should remove '(Official Track Visualiser)' string",
+    "funcParameter": "Track Title (Official Track Visualiser)",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(Official Visualiser)' string",
+    "funcParameter": "Track Title (Official Visualiser)",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(Official Visualizer)' string",
+    "funcParameter": "Track Title (Official Visualiser)",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(Visualiser)' string",
+    "funcParameter": "Track Title (Visualiser)",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(Visualizer)' string",
+    "funcParameter": "Track Title (Visualizer)",
+    "expectedValue": "Track Title"
+  },
+  {
     "description": "should remove (live) suffix",
     "funcParameter": "Track Title (Live)",
     "expectedValue": "Track Title"


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
Remove (Visualiser), (Visualizer) and variants from YouTube track titles, plus tests.

**Additional context**
<!-- Add any other context or screenshots here. -->
Cleans eg. [TENDER - Heavy (Official Visualiser)](https://www.youtube.com/watch?v=B4K8IGMWUz8) and similar.
