### PR TITLE
Update rules for Remastered, Version, Clean/Explicit filters

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -19,10 +19,10 @@ export interface FilterRule {
 }
 
 export const CLEAN_EXPLICIT_FILTER_RULES: FilterRule[] = [
-	// (Explicit) or [Explicit]
-	{ source: /\s[([]Explicit[)\]]/i, target: '' },
-	// (Clean) or [Clean]
-	{ source: /\s[([]Clean[)\]]/i, target: '' },
+	// (Explicit) / (Explicit Version) or [Explicit] / [Explicit Version]
+	{ source: /\s[([]Explicit(\sVersion)?[)\]]/i, target: '' },
+	// (Clean) / (Clean Version) or [Clean] / [Clean Version]
+	{ source: /\s[([]Clean(\sVersion)?[)\]]/i, target: '' },
 ];
 
 export const FEATURE_FILTER_RULES: FilterRule[] = [
@@ -137,6 +137,7 @@ export const VERSION_FILTER_RULES: FilterRule[] = [
 	{ source: /\s[([]Re-?recorded[)\]]$/i, target: '' },
 	// Your Cheatin' Heart (Single Version)
 	{ source: /\s[([]Single Version[)\]]$/i, target: '' },
+	// Dammit (Growing Up) (Radio Edit)
 	// Swallowed [Radio Edit]
 	{ source: /\s[([]Radio Edit[)\]]$/i, target: '' },
 	// 1999 - Edit

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -80,7 +80,8 @@ export const REMASTERED_FILTER_RULES: FilterRule[] = [
 	// Easy Living - 2003 Remastered
 	// Learning To Fly - 2001 Digital Remaster
 	// Red Right Hand - 2011 Remastered Version
-	{ source: /\s-\s\d{4}(\s-)?\s.*Re-?master(ed)?.*$/i, target: '' },
+	// Atrocity Exhibition - 2020 Digital Master
+	{ source: /\s-\s\d{4}(\s-)?\s.*(Re)?-?master(ed)?.*$/i, target: '' },
 	// Here Comes The Sun - Remastered
 	// 1979 - Remastered 2012
 	// 1979 - Remastered Version

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -67,7 +67,8 @@ export const REISSUE_FILTER_RULES: FilterRule[] = [
  */
 export const REMASTERED_FILTER_RULES: FilterRule[] = [
 	// Ticket To Ride - Live / Remastered
-	{ source: /Live\s\/\sRemastered/, target: 'Live' },
+	// White Wedding - Pt. 1 / Remastered 2002
+	{ source: /\s\/\sRemastered[^)\]]*/, target: '' },
 	// Mothership (Remastered)
 	// Let It Be (Remastered 2009)
 	// How The West Was Won [Remastered]
@@ -130,11 +131,12 @@ export const VERSION_FILTER_RULES: FilterRule[] = [
 	{ source: /\s[([]Album Version[)\]]$/, target: '' },
 	// I Melt With You (Rerecorded)
 	// When I Need You [Re-Recorded]
-	{ source: /\s[([]Re-?recorded[)\]]$/, target: '' },
+	{ source: /\s[([]Re-?recorded[)\]]$/i, target: '' },
 	// Your Cheatin' Heart (Single Version)
 	{ source: /\s[([]Single Version[)\]]$/, target: '' },
+	// 1999 - Edit
 	// All Over Now (Edit)
-	{ source: /\s[([]Edit[)\]]$/, target: '' },
+	{ source: /\s[-([]\s?Edit[)\]]?/i, target: '' },
 	// (I Can't Get No) Satisfaction - Mono Version
 	{ source: /\s-\sMono Version$/, target: '' },
 	// Ruby Tuesday - Stereo Version
@@ -161,6 +163,18 @@ export const VERSION_FILTER_RULES: FilterRule[] = [
 	// Prince of the Moment - Original 7" Version
 	// YMCA - Original Version 1978
 	{ source: /\s-\sOriginal.*Version(\s\d{4})?$/i, target: '' },
+	// Summer Girl - Video Version
+	// Take on Me (Video Version)
+	{ source: /\s[-([]\s?Video Version[)\]]?/i, target: '' },
+	// Invisible Touch - Platinum Collection Version
+	// That's All (Platinum Collection Version)
+	{ source: /\s[-([]\s?Platinum Collection Version[)\]]?/i, target: '' },
+	// Danger Zone - From "Top Gun" Original Soundtrack
+	// Hungry Eyes - From "Dirty Dancing" Soundtrack
+	// If You Leave - From "Pretty In Pink"
+	// If You Leave (From "Pretty In Pink" Soundtrack)
+	// Pretty In Pink (From "Pretty in Pink")
+	{ source: /\s[-([]\s?From ".*".*[)\]]?/i, target: '' },
 ];
 
 /**

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -155,8 +155,6 @@ export const VERSION_FILTER_RULES: FilterRule[] = [
 	{ source: /\s[([]Expanded.*[)\]]$/i, target: '' },
 	// Sound of White Noise - Expanded Edition
 	{ source: /\s-\sExpanded Edition$/i, target: '' },
-	// 6 Foot 7 Foot (Explicit Version)
-	{ source: /\s[([]Explicit Version[)\]]/i, target: '' },
 	// No Remorse (Bonus Track Edition)
 	{ source: /\s[([]Bonus Track Edition[)\]]/i, target: '' },
 	// Peace Sells...But Who's Buying (25th Anniversary)

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -130,11 +130,15 @@ export const VARIOUS_ARTISTS_FILTER_RULES: FilterRule[] = [
 export const VERSION_FILTER_RULES: FilterRule[] = [
 	// Love Will Come To You (Album Version)
 	{ source: /\s[([]Album Version[)\]]$/i, target: '' },
+	// Lithium (LP Version)
+	{ source: /\s[([]LP Version[)\]]$/i, target: '' },
 	// I Melt With You (Rerecorded)
 	// When I Need You [Re-Recorded]
 	{ source: /\s[([]Re-?recorded[)\]]$/i, target: '' },
 	// Your Cheatin' Heart (Single Version)
 	{ source: /\s[([]Single Version[)\]]$/i, target: '' },
+	// Swallowed [Radio Edit]
+	{ source: /\s[([]Radio Edit[)\]]$/i, target: '' },
 	// 1999 - Edit
 	// All Over Now (Edit)
 	{ source: /\s[-([]\s?Edit[)\]]?/i, target: '' },

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -34,9 +34,9 @@ export const FEATURE_FILTER_RULES: FilterRule[] = [
 export const LIVE_FILTER_RULES: FilterRule[] = [
 	// Track - Live
 	// Track - Live at
-	{ source: /\s-\sLive(\s.+)?$/, target: '' },
+	{ source: /\s-\sLive(\s.+)?$/i, target: '' },
 	// Track (Live)
-	{ source: /\s[([]Live[)\]]$/, target: '' },
+	{ source: /\s[([]Live[)\]]$/i, target: '' },
 ];
 
 export const NORMALIZE_FEATURE_FILTER_RULES = [
@@ -68,25 +68,25 @@ export const REISSUE_FILTER_RULES: FilterRule[] = [
 export const REMASTERED_FILTER_RULES: FilterRule[] = [
 	// Ticket To Ride - Live / Remastered
 	// White Wedding - Pt. 1 / Remastered 2002
-	{ source: /\s\/\sRemastered[^)\]]*/, target: '' },
+	{ source: /\s\/\sRemastered[^)\]]*/i, target: '' },
 	// Mothership (Remastered)
 	// Let It Be (Remastered 2009)
 	// How The West Was Won [Remastered]
 	// Ride the Lightning (Deluxe Remaster)
 	// ...And Justice For All (Remastered Deluxe Box Set)
-	{ source: /\s[([].*Re-?[Mm]aster(ed)?.*[)\]]$/, target: '' },
+	{ source: /\s[([].*Re-?master(ed)?.*[)\]]$/i, target: '' },
 	// Outside The Wall - 2011 - Remaster
 	// China Grove - 2006 Remaster
 	// Easy Living - 2003 Remastered
 	// Learning To Fly - 2001 Digital Remaster
 	// Red Right Hand - 2011 Remastered Version
-	{ source: /\s-\s\d{4}(\s-)?\s.*Re-?[Mm]aster(ed)?.*$/, target: '' },
+	{ source: /\s-\s\d{4}(\s-)?\s.*Re-?master(ed)?.*$/i, target: '' },
 	// Here Comes The Sun - Remastered
 	// 1979 - Remastered 2012
 	// 1979 - Remastered Version
-	{ source: /\s-\sRe-?[Mm]aster(ed)?.*$/, target: '' },
+	{ source: /\s-\sRe-?master(ed)?.*$/, target: '' },
 	// Wish You Were Here [Remastered] (Remastered Version)
-	{ source: /\s\[Remastered\]\s\(Remastered\sVersion\)$/, target: '' },
+	{ source: /\s\[Remastered\]\s\(Remastered\sVersion\)$/i, target: '' },
 ];
 
 export const SUFFIX_FILTER_RULES: FilterRule[] = [
@@ -128,27 +128,27 @@ export const VARIOUS_ARTISTS_FILTER_RULES: FilterRule[] = [
  */
 export const VERSION_FILTER_RULES: FilterRule[] = [
 	// Love Will Come To You (Album Version)
-	{ source: /\s[([]Album Version[)\]]$/, target: '' },
+	{ source: /\s[([]Album Version[)\]]$/i, target: '' },
 	// I Melt With You (Rerecorded)
 	// When I Need You [Re-Recorded]
 	{ source: /\s[([]Re-?recorded[)\]]$/i, target: '' },
 	// Your Cheatin' Heart (Single Version)
-	{ source: /\s[([]Single Version[)\]]$/, target: '' },
+	{ source: /\s[([]Single Version[)\]]$/i, target: '' },
 	// 1999 - Edit
 	// All Over Now (Edit)
 	{ source: /\s[-([]\s?Edit[)\]]?/i, target: '' },
 	// (I Can't Get No) Satisfaction - Mono Version
-	{ source: /\s-\sMono Version$/, target: '' },
+	{ source: /\s-\sMono Version$/i, target: '' },
 	// Ruby Tuesday - Stereo Version
 	{ source: /\s-\sStereo Version$/, target: '' },
 	// Pure McCartney (Deluxe Edition)
-	{ source: /\s\(Deluxe Edition\)$/, target: '' },
+	{ source: /\s\(Deluxe Edition\)$/i, target: '' },
 	// Ace of Spades (Expanded Edition)
 	// Overkill (Expanded Bonus Track Edition)
 	// On Parole (Expanded and Remastered)
-	{ source: /\s[([]Expanded.*[)\]]$/, target: '' },
+	{ source: /\s[([]Expanded.*[)\]]$/i, target: '' },
 	// Sound of White Noise - Expanded Edition
-	{ source: /\s-\sExpanded Edition$/, target: '' },
+	{ source: /\s-\sExpanded Edition$/i, target: '' },
 	// 6 Foot 7 Foot (Explicit Version)
 	{ source: /\s[([]Explicit Version[)\]]/i, target: '' },
 	// No Remorse (Bonus Track Edition)

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -84,7 +84,7 @@ export const REMASTERED_FILTER_RULES: FilterRule[] = [
 	// Here Comes The Sun - Remastered
 	// 1979 - Remastered 2012
 	// 1979 - Remastered Version
-	{ source: /\s-\sRe-?master(ed)?.*$/, target: '' },
+	{ source: /\s-\sRe-?master(ed)?.*$/i, target: '' },
 	// Wish You Were Here [Remastered] (Remastered Version)
 	{ source: /\s\[Remastered\]\s\(Remastered\sVersion\)$/i, target: '' },
 ];

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -140,7 +140,7 @@ export const VERSION_FILTER_RULES: FilterRule[] = [
 	// (I Can't Get No) Satisfaction - Mono Version
 	{ source: /\s-\sMono Version$/i, target: '' },
 	// Ruby Tuesday - Stereo Version
-	{ source: /\s-\sStereo Version$/, target: '' },
+	{ source: /\s-\sStereo Version$/i, target: '' },
 	// Pure McCartney (Deluxe Edition)
 	{ source: /\s\(Deluxe Edition\)$/i, target: '' },
 	// Ace of Spades (Expanded Edition)

--- a/test/fixtures/functions/remove-clean-explicit.json
+++ b/test/fixtures/functions/remove-clean-explicit.json
@@ -5,8 +5,18 @@
     "expectedValue": "Track"
   },
   {
+    "description": "should remove [Explicit Version] suffix",
+    "funcParameter": "Track [Explicit Version]",
+    "expectedValue": "Track"
+  },
+  {
     "description": "should remove (Explicit) suffix",
     "funcParameter": "Track (Explicit)",
+    "expectedValue": "Track"
+  },
+  {
+    "description": "should remove (Explicit Version) suffix",
+    "funcParameter": "Track (Explicit Version)",
     "expectedValue": "Track"
   },
   {
@@ -15,8 +25,18 @@
     "expectedValue": "Track"
   },
   {
+    "description": "should remove [Clean Version] suffix",
+    "funcParameter": "Track [Clean Version]",
+    "expectedValue": "Track"
+  },
+  {
     "description": "should remove (Clean) suffix",
     "funcParameter": "Track (Clean)",
+    "expectedValue": "Track"
+  },
+  {
+    "description": "should remove (Clean Version) suffix",
+    "funcParameter": "Track (Clean Version)",
     "expectedValue": "Track"
   }
 ]

--- a/test/fixtures/functions/remove-remastered.json
+++ b/test/fixtures/functions/remove-remastered.json
@@ -60,6 +60,11 @@
     "expectedValue": "Track Title"
   },
   {
+    "description": "should remove '- YYYY Digital Master' string",
+    "funcParameter": "Track Title - 2020 Digital Master",
+    "expectedValue": "Track Title"
+  },
+  {
     "description": "should remove '- YYYY Remastered Version' string",
     "funcParameter": "Track Title - 2011 Remastered Version",
     "expectedValue": "Track Title"

--- a/test/fixtures/functions/remove-version.json
+++ b/test/fixtures/functions/remove-version.json
@@ -110,16 +110,6 @@
     "expectedValue": "Album Title"
   },
   {
-    "description": "should remove '(Explicit Version)' string",
-    "funcParameter": "Album Title (Explicit Version)",
-    "expectedValue": "Album Title"
-  },
-  {
-    "description": "should remove '[Explicit Version]' string",
-    "funcParameter": "Album Title [Explicit Version]",
-    "expectedValue": "Album Title"
-  },
-  {
     "description": "should remove '(Bonus Track Edition)' string",
     "funcParameter": "Album Title (Bonus Track Edition)",
     "expectedValue": "Album Title"

--- a/test/fixtures/functions/remove-version.json
+++ b/test/fixtures/functions/remove-version.json
@@ -15,6 +15,16 @@
     "expectedValue": "Track Title"
   },
   {
+    "description": "should remove '(LP Version)' string",
+    "funcParameter": "Track Title (LP Version)",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '[LP Version]' string",
+    "funcParameter": "Track Title [LP Version]",
+    "expectedValue": "Track Title"
+  },
+  {
     "description": "should remove '(Rerecorded)' string",
     "funcParameter": "Track Title (Rerecorded)",
     "expectedValue": "Track Title"
@@ -37,6 +47,16 @@
   {
     "description": "should remove '(Single Version)' string",
     "funcParameter": "Track Title (Single Version)",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(Radio Edit)' string",
+    "funcParameter": "Track Title (Radio Edit)",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '[Radio Edit]' string",
+    "funcParameter": "Track Title [Radio Edit]",
     "expectedValue": "Track Title"
   },
   {

--- a/test/fixtures/functions/remove-version.json
+++ b/test/fixtures/functions/remove-version.json
@@ -25,18 +25,23 @@
     "expectedValue": "Track Title"
   },
   {
-    "description": "should remove '(Re-recorded)' string",
-    "funcParameter": "Track Title (Rerecorded)",
+    "description": "should remove '(Re-Recorded)' string",
+    "funcParameter": "Track Title (Re-Recorded)",
     "expectedValue": "Track Title"
   },
   {
-    "description": "should remove '[Re-recorded]' string",
-    "funcParameter": "Track Title [Rerecorded]",
+    "description": "should remove '[Re-Recorded]' string",
+    "funcParameter": "Track Title [Re-Recorded]",
     "expectedValue": "Track Title"
   },
   {
     "description": "should remove '(Single Version)' string",
     "funcParameter": "Track Title (Single Version)",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '- Edit' string",
+    "funcParameter": "Track Title - Edit",
     "expectedValue": "Track Title"
   },
   {
@@ -142,6 +147,36 @@
   {
     "description": "should remove '- Original Version YYYY' suffix",
     "funcParameter": "Track Title - Original Version 1978",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '- Video Version' string",
+    "funcParameter": "Track Title - Video Version",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(Video Version)' string",
+    "funcParameter": "Track Title (Video Version)",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '- From \"Movie Title\"' string",
+    "funcParameter": "Track Title - From \"Movie Title\"",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '- From \"Movie Title\" Soundtrack' string",
+    "funcParameter": "Track Title - From \"Movie Title\" Soundtrack",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(From \"Movie Title\")' string",
+    "funcParameter": "Track Title (From \"Movie Title\")",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(From \"Movie Title\" Soundtrack)' string",
+    "funcParameter": "Track Title (From \"Movie Title\" Soundtrack)",
     "expectedValue": "Track Title"
   }
 ]

--- a/test/fixtures/functions/remove-version.json
+++ b/test/fixtures/functions/remove-version.json
@@ -160,6 +160,16 @@
     "expectedValue": "Track Title"
   },
   {
+    "description": "should remove '- Platinum Collection Version' string",
+    "funcParameter": "Track Title - Platinum Collection Version",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(Platinum Collection Version)' string",
+    "funcParameter": "Track Title (Platinum Collection Version)",
+    "expectedValue": "Track Title"
+  },
+  {
     "description": "should remove '- From \"Movie Title\"' string",
     "funcParameter": "Track Title - From \"Movie Title\"",
     "expectedValue": "Track Title"


### PR DESCRIPTION
**Describe the changes you made**

- Updated Live, Remastered, and Version rules to be case insensitive
- Minor edits to 2 existing Remastered rules, 2 existing Version rules, and 2 existing Clean/Explicit rules so they are more adaptable
- Addition of 5 new Version rules with title examples

**Additional context**
Initially, I was just going to update the first Remastered rule for [this](https://www.last.fm/music/Billy+Idol/_/White+Wedding+-+Pt.+1+%2F+Remastered+2002) and similar cases, as the existing version was too limited and only applied when "Live" was included. Then I noticed a few others that could be updated/added, including case insensitivity. Not all sites will necessarily capitalize this text when included in the title.
The rule for **From "Movie Title"** was added to the Version filter because that seemed to be the most appropriate spot for it—part of a collection of additional information that shouldn't be included with the title—and it didn't seem like it required a separate filter of its own.
Lastly, it seems debatable that Clean/Explicit even needs its own filter, as it could be integrated into Version. But since it is currently its own filter, it is redundant to have "Explicit Version" (but no "Clean Version") in the Version rules.