### PR TITLE
Add `(Original Video|Song)`

### DIFF
--- a/src/rules.ts
+++ b/src/rules.ts
@@ -189,6 +189,8 @@ export const YOUTUBE_TRACK_FILTER_RULES: FilterRule[] = [
 	{ source: /\((of+icial\s*)?((music|hd)\s*)?(video|audio)\)/i, target: '' },
 	// - (Official)? (Music)? Video|Audio
 	{ source: /-\s(of+icial\s*)?(music\s*)?(video|audio)$/i, target: '' },
+	// ((Whatever)? (Original) Video|Song)
+	{ source: /\(.*?original\s*(video|song)\)/i, target: '' },
 	// ((Whatever)? Album Track)
 	{ source: /\(.*Album\sTrack\)/i, target: '' },
 	// (Official)

--- a/test/fixtures/functions/youtube.json
+++ b/test/fixtures/functions/youtube.json
@@ -205,6 +205,21 @@
     "expectedValue": "Video Killed the Radio Star"
   },
   {
+    "description": "should remove '(Original Video)' string",
+    "funcParameter": "Track Title (Original Video)",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(Original Song)' string",
+    "funcParameter": "Track Title (Original Song)",
+    "expectedValue": "Track Title"
+  },
+  {
+    "description": "should remove '(Whatever Original Song)' string",
+    "funcParameter": "Track Title (Whatever Original Song)",
+    "expectedValue": "Track Title"
+  },
+  {
     "description": "should remove '(official)' string",
     "funcParameter": "Track Title (Official)",
     "expectedValue": "Track Title"


### PR DESCRIPTION
**Describe the changes you made**
<!-- A clear and concise description of changes proposed in this pull request. -->
some music videos have this, scrobbles wrong or not at all because of that (web-scrobbler)

**Additional context**
<!-- Add any other context or screenshots here. -->
videos in the wild:
- "Original Video": https://www.youtube.com/watch?v=WHYBB12CMU8
- "Original Song":https://www.youtube.com/watch?v=U6evzTaBGm4
- "(whatever) Original Song": https://www.youtube.com/watch?v=1xEfMnXyGkA

fixes web-scrobbler/web-scrobbler#5704